### PR TITLE
Update to include all of the alcatraz logic

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -17,6 +17,6 @@ var app = new EmberAddon();
 // modules that you would like to import into your application
 // please specify an object with the list of modules as keys
 // along with the exports of each module as its value.
-app.import('bower_components/alcatraz-client-js/index.js');
+// app.import('bower_components/alcatraz-client-js/index.js');
 
 module.exports = app.toTree();

--- a/Brocfile.js
+++ b/Brocfile.js
@@ -17,6 +17,5 @@ var app = new EmberAddon();
 // modules that you would like to import into your application
 // please specify an object with the list of modules as keys
 // along with the exports of each module as its value.
-// app.import('bower_components/alcatraz-client-js/index.js');
 
 module.exports = app.toTree();

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A javascript client to communicate with the Alcatraz PCI-compliant data store.
 
 ## Installation
 
-* Run `ember addon:install ember-cli-alcatraz-client` in the commandline
+* Run `ember install ember-cli-alcatraz-client` in the commandline
 
 ## Usage
 
@@ -17,3 +17,84 @@ ENV.alcatrazClient = {
 ```
 
 Your application will now have to the `Alcatraz` object, which you can use to make requests.
+
+* Store a card in Alcatraz with `Alcatraz.storeCard()`
+
+```javascript
+import Alcatraz from 'ember-cli-alcatraz-client/alcatraz';
+
+export default Ember.Component.extend({
+  storeCard: function(){
+    var data = {
+      name: 'Jane Doe',
+      number: '4111111111111111',
+      expiration_month: '5',
+      expiration_year: '2015',
+      cvv: '123',
+      postal_code: '94107',
+      country_code: 'US'
+    },
+    Alcatraz.storeCard(data, function(response) {
+      console.log(response);
+    });
+  }
+});
+```
+
+* Retrieve a card stored in Alcatraz with `Alcatraz.getCard()`
+
+```javascript
+import Alcatraz from 'ember-cli-alcatraz-client/alcatraz';
+
+export default Ember.Component.extend({
+  passCode: '123kljakdfladfjad',
+  publicKey: 'q099q0elkajdf',
+  secureId: 'a093jakldf',
+
+  getCard: function(){
+    Alcatraz.getCard(this.get('publicKey'), passcode, this.get('secureId'), function(response) {
+      if (response.card) {
+        console.log(response.card['number']);
+      }
+    });
+  }
+});
+```
+
+* Store arbitrary secure data with `Alcatraz.storeData()`
+
+```javascript
+import Alcatraz from 'ember-cli-alcatraz-client/alcatraz';
+
+export default Ember.Component.extend({
+  storeData: function(){
+    var data = {
+      ssn: '123-45-6789'
+    },
+    Alcatraz.storeData(data, function(response) {
+      console.log(response);
+    });
+  }
+});
+```
+
+* Retrieve arbitrary secure data with `Alcatraz.getData()`
+
+```javascript
+import Alcatraz from 'ember-cli-alcatraz-client/alcatraz';
+
+export default Ember.Component.extend({
+  passCode: '123kljakdfladfjad',
+  publicKey: 'q099q0elkajdf',
+  secureId: 'a093jakldf',
+
+  getData: function(){
+    Alcatraz.getData(this.get('publicKey'), passcode, this.get('secureId'), function(response) {
+      if (response.ssn) {
+        console.log(response.ssn);
+      }
+    });
+  }
+});
+```
+

--- a/addon/alcatraz.js
+++ b/addon/alcatraz.js
@@ -1,0 +1,60 @@
+var alcatraz = {
+
+  storeCard: function(data, callback) {
+    return $.ajax({
+      url: this.rootUrl + "/cards",
+      dataType: "jsonp",
+      data: $.extend({}, data, {
+        _method: 'post'
+      }),
+      success: callback
+    })
+  },
+
+  getCard: function(key, passcode, id, callback) {
+    return $.jsonp({
+      url: this.rootUrl + "/cards/" + id,
+      callback: 'callback',
+      dataType: "json",
+      callbackParameter: "callback",
+      data: {
+        auth: {
+          public_key: key,
+          passcode: passcode
+        }
+      },
+      success: callback,
+      error: callback
+    })
+  },
+
+  storeData: function(data, callback) {
+    return $.ajax({
+      url: this.rootUrl + "/secure_data",
+      dataType: "jsonp",
+      data: $.extend({}, data, {
+        _method: 'post'
+      }),
+      success: callback
+    });
+  },
+
+  getData: function(key, passcode, id, callback) {
+    return $.jsonp({
+      url: this.rootUrl + "/secure_data/" + id,
+      callback: 'callback',
+      dataType: "json",
+      callbackParameter: "callback",
+      data: {
+        auth: {
+          public_key: key,
+          passcode: passcode
+        }
+      },
+      success: callback,
+      error: callback
+    })
+  }
+}
+
+export default alcatraz;

--- a/addon/alcatraz.js
+++ b/addon/alcatraz.js
@@ -1,18 +1,20 @@
+import Ember from 'ember';
+
 var alcatraz = {
 
   storeCard: function(data, callback) {
-    return $.ajax({
+    return Ember.$.ajax({
       url: this.rootUrl + "/cards",
       dataType: "jsonp",
-      data: $.extend({}, data, {
+      data: Ember.$.extend({}, data, {
         _method: 'post'
       }),
       success: callback
-    })
+    });
   },
 
   getCard: function(key, passcode, id, callback) {
-    return $.jsonp({
+    return Ember.$.jsonp({
       url: this.rootUrl + "/cards/" + id,
       callback: 'callback',
       dataType: "json",
@@ -25,14 +27,14 @@ var alcatraz = {
       },
       success: callback,
       error: callback
-    })
+    });
   },
 
   storeData: function(data, callback) {
-    return $.ajax({
+    return Ember.$.ajax({
       url: this.rootUrl + "/secure_data",
       dataType: "jsonp",
-      data: $.extend({}, data, {
+      data: Ember.$.extend({}, data, {
         _method: 'post'
       }),
       success: callback
@@ -40,7 +42,7 @@ var alcatraz = {
   },
 
   getData: function(key, passcode, id, callback) {
-    return $.jsonp({
+    return Ember.$.jsonp({
       url: this.rootUrl + "/secure_data/" + id,
       callback: 'callback',
       dataType: "json",
@@ -53,8 +55,8 @@ var alcatraz = {
       },
       success: callback,
       error: callback
-    })
+    });
   }
-}
+};
 
 export default alcatraz;

--- a/addon/alcatraz.js
+++ b/addon/alcatraz.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 
-var alcatraz = {
+var alcatraz = Ember.Object.extend({
 
   storeCard: function(data, callback) {
     return Ember.$.ajax({
@@ -57,6 +57,6 @@ var alcatraz = {
       error: callback
     });
   }
-};
+});
 
 export default alcatraz;

--- a/app/alactraz.js
+++ b/app/alactraz.js
@@ -1,0 +1,2 @@
+import Alcatraz from 'ember-cli-alcatraz-client/alcatraz';
+export default Alcatraz;

--- a/app/initializers/alcatraz-client.js
+++ b/app/initializers/alcatraz-client.js
@@ -1,8 +1,8 @@
 import config from '../config/environment';
+import Alcatraz from 'ember-cli-alcatraz-client/alcatraz';
 
 export function initialize() {
-  if (!window.Alcatraz) { return; };
-  window.Alcatraz.rootUrl = config.alcatrazClient.rootUrl;
+  Alcatraz.rootUrl = config.alcatrazClient.rootUrl;
 }
 
 export default {

--- a/blueprints/ember-cli-alcatraz-client/index.js
+++ b/blueprints/ember-cli-alcatraz-client/index.js
@@ -1,10 +1,3 @@
 module.exports = {
 
-  beforeInstall: function(options) {
-    // return this.addBowerPackageToProject('alcatraz-client');
-  },
-
-  afterInstall: function() {
-    // return this.addBowerPackageToProject('alcatraz-client');
-  }
 };

--- a/blueprints/ember-cli-alcatraz-client/index.js
+++ b/blueprints/ember-cli-alcatraz-client/index.js
@@ -1,8 +1,10 @@
 module.exports = {
-  normalizeEntityName: function() {
+
+  beforeInstall: function(options) {
+    // return this.addBowerPackageToProject('alcatraz-client');
   },
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('alcatraz-client-js');
+    // return this.addBowerPackageToProject('alcatraz-client');
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,5 @@
     "qunit": "~1.17.1"
   },
   "devDependencies": {
-    "alcatraz-client-js": "*"
   }
 }

--- a/index.js
+++ b/index.js
@@ -11,8 +11,7 @@ module.exports = {
   },
 
   included: function(app, parentAddon) {
-    this._super.included(app);
-
-    app.import(app.bowerDirectory + '/alcatraz-client-js/index.js');
+    this._super.included(app)
+    app.import('vendor/jquery-jsonp.js');;
   }
 };

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
     "ember-cli": "0.2.3",
-    "ember-cli-babel": "^4.0.0",
     "ember-cli-app-version": "0.3.1",
+    "ember-cli-babel": "^4.0.0",
     "ember-cli-content-security-policy": "0.3.0",
     "ember-cli-dependency-checker": "0.0.7",
     "ember-cli-htmlbars": "0.7.4",
@@ -39,5 +39,6 @@
   ],
   "ember-addon": {
     "configPath": "tests/dummy/config"
-  }
+  },
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "0.3.8",
     "ember-cli-uglify": "1.0.1",
-    "ember-data": "1.0.0-beta.15",
     "ember-export-application-global": "^1.0.2",
     "express": "^4.8.5",
     "glob": "^4.0.5"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
-    "ember-cli": "0.2.0-beta.1",
+    "ember-cli": "0.2.3",
     "ember-cli-babel": "^4.0.0",
     "ember-cli-app-version": "0.3.1",
     "ember-cli-content-security-policy": "0.3.0",

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -37,6 +37,10 @@ module.exports = function(environment) {
     ENV.APP.LOG_VIEW_LOOKUPS = false;
 
     ENV.APP.rootElement = '#ember-testing';
+
+    ENV.alcatrazClient = {
+      rootUrl: 'http://domain.com'
+    };
   }
 
   if (environment === 'production') {

--- a/vendor/jquery-jsonp.js
+++ b/vendor/jquery-jsonp.js
@@ -1,0 +1,285 @@
+/*
+ * jQuery JSONP Core Plugin 2.4.0 (2012-08-21)
+ *
+ * https://github.com/jaubourg/jquery-jsonp
+ *
+ * Copyright (c) 2012 Julian Aubourg
+ *
+ * This document is licensed as free software under the terms of the
+ * MIT License: http://www.opensource.org/licenses/mit-license.php
+ */
+( function( $ ) {
+
+  // ###################### UTILITIES ##
+
+  // Noop
+  function noop() {
+  }
+
+  // Generic callback
+  function genericCallback( data ) {
+    lastValue = [ data ];
+  }
+
+  // Call if defined
+  function callIfDefined( method , object , parameters ) {
+    return method && method.apply( object.context || object , parameters );
+  }
+
+  // Give joining character given url
+  function qMarkOrAmp( url ) {
+    return /\?/ .test( url ) ? "&" : "?";
+  }
+
+  var // String constants (for better minification)
+    STR_ASYNC = "async",
+    STR_CHARSET = "charset",
+    STR_EMPTY = "",
+    STR_ERROR = "error",
+    STR_INSERT_BEFORE = "insertBefore",
+    STR_JQUERY_JSONP = "_jqjsp",
+    STR_ON = "on",
+    STR_ON_CLICK = STR_ON + "click",
+    STR_ON_ERROR = STR_ON + STR_ERROR,
+    STR_ON_LOAD = STR_ON + "load",
+    STR_ON_READY_STATE_CHANGE = STR_ON + "readystatechange",
+    STR_READY_STATE = "readyState",
+    STR_REMOVE_CHILD = "removeChild",
+    STR_SCRIPT_TAG = "<script>",
+    STR_SUCCESS = "success",
+    STR_TIMEOUT = "timeout",
+
+    // Window
+    win = window,
+    // Deferred
+    Deferred = $.Deferred,
+    // Head element
+    head = $( "head" )[ 0 ] || document.documentElement,
+    // Page cache
+    pageCache = {},
+    // Counter
+    count = 0,
+    // Last returned value
+    lastValue,
+
+    // ###################### DEFAULT OPTIONS ##
+    xOptionsDefaults = {
+      //beforeSend: undefined,
+      //cache: false,
+      callback: STR_JQUERY_JSONP,
+      //callbackParameter: undefined,
+      //charset: undefined,
+      //complete: undefined,
+      //context: undefined,
+      //data: "",
+      //dataFilter: undefined,
+      //error: undefined,
+      //pageCache: false,
+      //success: undefined,
+      //timeout: 0,
+      //traditional: false,
+      url: location.href
+    },
+
+    // opera demands sniffing :/
+    opera = win.opera,
+
+    // IE < 10
+    oldIE = !!$( "<div>" ).html( "<!--[if IE]><i><![endif]-->" ).find("i").length;
+
+  // ###################### MAIN FUNCTION ##
+  function jsonp( xOptions ) {
+
+    // Build data with default
+    xOptions = $.extend( {} , xOptionsDefaults , xOptions );
+
+    // References to xOptions members (for better minification)
+    var successCallback = xOptions.success,
+      errorCallback = xOptions.error,
+      completeCallback = xOptions.complete,
+      dataFilter = xOptions.dataFilter,
+      callbackParameter = xOptions.callbackParameter,
+      successCallbackName = xOptions.callback,
+      cacheFlag = xOptions.cache,
+      pageCacheFlag = xOptions.pageCache,
+      charset = xOptions.charset,
+      url = xOptions.url,
+      data = xOptions.data,
+      timeout = xOptions.timeout,
+      pageCached,
+
+      // Abort/done flag
+      done = 0,
+
+      // Life-cycle functions
+      cleanUp = noop,
+
+      // Support vars
+      supportOnload,
+      supportOnreadystatechange,
+
+      // Request execution vars
+      firstChild,
+      script,
+      scriptAfter,
+      timeoutTimer;
+
+    // If we have Deferreds:
+    // - substitute callbacks
+    // - promote xOptions to a promise
+    Deferred && Deferred(function( defer ) {
+      defer.done( successCallback ).fail( errorCallback );
+      successCallback = defer.resolve;
+      errorCallback = defer.reject;
+    }).promise( xOptions );
+
+    // Create the abort method
+    xOptions.abort = function() {
+      !( done++ ) && cleanUp();
+    };
+
+    // Call beforeSend if provided (early abort if false returned)
+    if ( callIfDefined( xOptions.beforeSend , xOptions , [ xOptions ] ) === !1 || done ) {
+      return xOptions;
+    }
+
+    // Control entries
+    url = url || STR_EMPTY;
+    data = data ? ( (typeof data) == "string" ? data : $.param( data , xOptions.traditional ) ) : STR_EMPTY;
+
+    // Build final url
+    url += data ? ( qMarkOrAmp( url ) + data ) : STR_EMPTY;
+
+    // Add callback parameter if provided as option
+    callbackParameter && ( url += qMarkOrAmp( url ) + encodeURIComponent( callbackParameter ) + "=?" );
+
+    // Add anticache parameter if needed
+    !cacheFlag && !pageCacheFlag && ( url += qMarkOrAmp( url ) + "_" + ( new Date() ).getTime() + "=" );
+
+    // Replace last ? by callback parameter
+    url = url.replace( /=\?(&|$)/ , "=" + successCallbackName + "$1" );
+
+    // Success notifier
+    function notifySuccess( json ) {
+
+      if ( !( done++ ) ) {
+
+        cleanUp();
+        // Pagecache if needed
+        pageCacheFlag && ( pageCache [ url ] = { s: [ json ] } );
+        // Apply the data filter if provided
+        dataFilter && ( json = dataFilter.apply( xOptions , [ json ] ) );
+        // Call success then complete
+        callIfDefined( successCallback , xOptions , [ json , STR_SUCCESS, xOptions ] );
+        callIfDefined( completeCallback , xOptions , [ xOptions , STR_SUCCESS ] );
+
+      }
+    }
+
+    // Error notifier
+    function notifyError( type ) {
+
+      if ( !( done++ ) ) {
+
+        // Clean up
+        cleanUp();
+        // If pure error (not timeout), cache if needed
+        pageCacheFlag && type != STR_TIMEOUT && ( pageCache[ url ] = type );
+        // Call error then complete
+        callIfDefined( errorCallback , xOptions , [ xOptions , type ] );
+        callIfDefined( completeCallback , xOptions , [ xOptions , type ] );
+
+      }
+    }
+
+    // Check page cache
+    if ( pageCacheFlag && ( pageCached = pageCache[ url ] ) ) {
+
+      pageCached.s ? notifySuccess( pageCached.s[ 0 ] ) : notifyError( pageCached );
+
+    } else {
+
+      // Install the generic callback
+      // (BEWARE: global namespace pollution ahoy)
+      win[ successCallbackName ] = genericCallback;
+
+      // Create the script tag
+      script = $( STR_SCRIPT_TAG )[ 0 ];
+      script.id = STR_JQUERY_JSONP + count++;
+
+      // Set charset if provided
+      if ( charset ) {
+        script[ STR_CHARSET ] = charset;
+      }
+
+      opera && opera.version() < 11.60 ?
+        // onerror is not supported: do not set as async and assume in-order execution.
+        // Add a trailing script to emulate the event
+        ( ( scriptAfter = $( STR_SCRIPT_TAG )[ 0 ] ).text = "document.getElementById('" + script.id + "')." + STR_ON_ERROR + "()" )
+      :
+        // onerror is supported: set the script as async to avoid requests blocking each others
+        ( script[ STR_ASYNC ] = STR_ASYNC )
+
+      ;
+
+      // Internet Explorer: event/htmlFor trick
+      if ( oldIE ) {
+        script.htmlFor = script.id;
+        script.event = STR_ON_CLICK;
+      }
+
+      // Attached event handlers
+      script[ STR_ON_LOAD ] = script[ STR_ON_ERROR ] = script[ STR_ON_READY_STATE_CHANGE ] = function ( result ) {
+
+        // Test readyState if it exists
+        if ( !script[ STR_READY_STATE ] || !/i/.test( script[ STR_READY_STATE ] ) ) {
+
+          try {
+
+            script[ STR_ON_CLICK ] && script[ STR_ON_CLICK ]();
+
+          } catch( _ ) {}
+
+          result = lastValue;
+          lastValue = 0;
+          result ? notifySuccess( result[ 0 ] ) : notifyError( STR_ERROR );
+
+        }
+      };
+
+      // Set source
+      script.src = url;
+
+      // Re-declare cleanUp function
+      cleanUp = function( i ) {
+        timeoutTimer && clearTimeout( timeoutTimer );
+        script[ STR_ON_READY_STATE_CHANGE ] = script[ STR_ON_LOAD ] = script[ STR_ON_ERROR ] = null;
+        head[ STR_REMOVE_CHILD ]( script );
+        scriptAfter && head[ STR_REMOVE_CHILD ]( scriptAfter );
+      };
+
+      // Append main script
+      head[ STR_INSERT_BEFORE ]( script , ( firstChild = head.firstChild ) );
+
+      // Append trailing script if needed
+      scriptAfter && head[ STR_INSERT_BEFORE ]( scriptAfter , firstChild );
+
+      // If a timeout is needed, install it
+      timeoutTimer = timeout > 0 && setTimeout( function() {
+        notifyError( STR_TIMEOUT );
+      } , timeout );
+
+    }
+
+    return xOptions;
+  }
+
+  // ###################### SETUP FUNCTION ##
+  jsonp.setup = function( xOptions ) {
+    $.extend( xOptionsDefaults , xOptions );
+  };
+
+  // ###################### INSTALL in jQuery ##
+  $.jsonp = jsonp;
+
+} )( jQuery );


### PR DESCRIPTION
@MattNguyen This updates the add so that it contains all of the Alcatraz logic (instead of relying on an external library)

Also:
- fixes `$.jsonp` not being recognized bc jquery-jsonp was missing.
- updates Ember CLI

We should probably get rid of https://github.com/CheckMateIO/alcatraz-client-js now that all the logic is within this addon.
